### PR TITLE
Modified visualize_precision_recall methods to return matplotlib Figure

### DIFF
--- a/polyfuzz/metrics.py
+++ b/polyfuzz/metrics.py
@@ -7,6 +7,7 @@ from typing import Tuple, List, Mapping
 from matplotlib import gridspec
 from matplotlib.cm import get_cmap
 from matplotlib.lines import Line2D
+from matplotlib.figure import Figure
 
 
 def precision_recall_curve(matches: pd.DataFrame,
@@ -57,7 +58,7 @@ def visualize_precision_recall(matches: Mapping[str, pd.DataFrame],
                                min_precisions: Mapping[str, List[float]],
                                recall: Mapping[str, List[float]],
                                kde: bool = True,
-                               save_path: str = None):
+                               save_path: str = None) -> Figure:
     """ Visualize the precision recall curve for one or more models
 
     Arguments:
@@ -129,7 +130,6 @@ def visualize_precision_recall(matches: Mapping[str, pd.DataFrame],
     ax1.set_xlabel(r"$\bf{Precision}$" + "\n(Minimum Similarity)")
     ax1.set_ylabel(r"$\bf{Recall}$" + "\n(Percentage Matched)")
 
-
     # Similarity Histogram
     if kde:
         for color, model_name in zip(cmap.colors, model_names):
@@ -159,3 +159,5 @@ def visualize_precision_recall(matches: Mapping[str, pd.DataFrame],
 
     if save_path:
         plt.savefig(save_path, dpi=300)
+
+    return fig

--- a/polyfuzz/polyfuzz.py
+++ b/polyfuzz/polyfuzz.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd
-from typing import List, Mapping, Union, Iterable
+from typing import List, Mapping, Union, Iterable, Any
 
 from polyfuzz.linkage import single_linkage
 from polyfuzz.utils import check_matches, check_grouped, create_logger
@@ -149,7 +149,7 @@ class PolyFuzz:
     def visualize_precision_recall(self,
                                    kde: bool = False,
                                    save_path: str = None
-                                   ):
+                                   ) -> Any:
         """ Calculate and visualize precision-recall curves
 
         A minimum similarity score might be used to identify
@@ -189,7 +189,7 @@ class PolyFuzz:
             self.recalls[name] = recall
             self.average_precisions[name] = average_precision
 
-        visualize_precision_recall(self.matches, self.min_precisions, self.recalls, kde, save_path)
+        return visualize_precision_recall(self.matches, self.min_precisions, self.recalls, kde, save_path)
 
     def group(self,
               model: Union[str, BaseMatcher] = None,


### PR DESCRIPTION
rendering the plots in a dark themed Jupyter notebook  Results in unreadable titles (Black on dark).  By returning the matplotlib Figure object, the user has the option to modify the plot's appearance (e.g., fig.set_face_color('white').