### PR TITLE
Update sparse-dot-topn to v1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,7 @@ sbert_packages = [
     "sentence-transformers>=0.4.1"
 ]
 
-fast_cosine = [
-    "sparse_dot_topn>=0.2.9"
-]
+fast_cosine = ["sparse_dot_topn>=1.1.1"]
 
 embeddings_packages = [
     "torch>=1.4.0", 


### PR DESCRIPTION
Hi @MaartenGr,

We recently refactored [sparse-dot-topn](https://github.com/ing-bank/sparse_dot_topn) significantly and [release v1](https://github.com/ing-bank/sparse_dot_topn/releases/tag/v1.0.0).

The most significant improvements are:

- Faster implementation with lower memory overhead
- new bindings using Nanobind which avoids the installation issues with Cython
- Default parallelism with OpenMP

The changes are significant enough that we released a new major version which deprecates `awsome_cossim_topn`.
I also noticed that you encountered a bug when top-n is 1, I added a test-case for this and the issue no longer exists.

The new implementation does not sort the scores but rather returns the matrix in the order as if you didn't select the top-n,
i.e. `sp_matmul(A, B) == sp_matmul_topn(A, B, B.shape[1])`.
It wasn't directly clear to me if you (implicitly) depend on the result being sorted so I left sorting on (it has no performance penalty).