### PR TITLE
Fix deprecated matplotlib import in metrics.py

### DIFF
--- a/polyfuzz/metrics.py
+++ b/polyfuzz/metrics.py
@@ -5,7 +5,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from typing import Tuple, List, Mapping
 from matplotlib import gridspec
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 from matplotlib.lines import Line2D
 
 


### PR DESCRIPTION
Fixes breaking change -- get_cmap cannot be imported from matplotlib.cm, as it was removed from matplotlib.cm as a standalone function as can be seen in the [history of matplotlibs' cm module here.](https://github.com/matplotlib/matplotlib/commit/7f23ee15f80c279100f5909ca1d681c575aeb23b)

as suggested I changed the import to use matplot.pyplot instead.  If this is not changed polyfuzz will raise an ImportError during importing.